### PR TITLE
0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,23 +42,23 @@ When a serialized error with a known `name` is encountered, it will be deseriali
 import {deserializeError} from 'serialize-error';
 
 const known = deserializeError({
-	name: 'TypeError',
-	message: '🦄'
+  name: 'TypeError',
+  message: '🦄'
 });
 
 console.log(known);
 //=> [TypeError: 🦄] <-- Still a TypeError
 
 const unknown = deserializeError({
-	name: 'TooManyCooksError',
-	message: '🦄'
+  name: 'TooManyCooksError',
+  message: '🦄'
 });
 
 console.log(unknown);
 //=> [Error: 🦄] <-- Just a regular Error
 ```
 
-The [list of known errors](./src/constructors.js) can be extended globally. This also works if `serialize-error-cjs` is a sub-dependency that's not used directly.
+The [list of known errors](./src/constructors.ts) can be extended globally. This also works if `serialize-error-cjs` is a sub-dependency that's not used directly.
 
 ```js
 import {errorConstructors} from 'serialize-error-cjs';
@@ -67,66 +67,19 @@ import {MyCustomError} from './errors.js'
 errorConstructors.set('MyCustomError', MyCustomError)
 ```
 
-**Warning:** Only simple and standard error constructors are supported, like `new MyCustomError(message)`. If your error constructor **requires** a second parameter or does not accept a string as first parameter, adding it to this map **will** break the deserialization.
+**Warning:** Only simple errors are supported. The constructor of errors classes will **NOT** be called during deserialization, so if your custom error relies on it being called it will not work.
 
 ## API
 
-<!-- ### serializeError(value, options?) -->
-### serializeError(value)
+### serializeError(value: T extends Error): SerializedError
 
 Serialize an `Error` object into a plain object.
 
 - Custom properties **NOT** are preserved.
 - Non-enumerable properties are kept non-enumerable (name, message, stack).
 - Circular references are **NOT** handled.
-<!-- - Non-error values are passed through. -->
-<!-- - Enumerable properties are kept enumerable (all properties besides the non-enumerable ones). -->
-<!-- - Buffer properties are replaced with `[object Buffer]`. -->
-<!-- - If the input object has a `.toJSON()` method, then it's called instead of serializing the object's properties. -->
-<!-- - It's up to `.toJSON()` implementation to handle circular references and enumerability of the properties. -->
 
-### value
-
-<!-- Type: `Error | unknown` -->
-Type: `Error`
-
-<!--
-### toJSON implementation examples
-
-```js
-import {serializeError} from 'serialize-error-cjs';
-
-class ErrorWithDate extends Error {
-	constructor() {
-		super();
-		this.date = new Date();
-	}
-}
-
-const error = new ErrorWithDate();
-
-serializeError(error);
-// => {date: '1970-01-01T00:00:00.000Z', name, message, stack}
-```
-
-```js
-import {serializeError} from 'serialize-error-cjs';
-
-const error = new Error('Unicorn');
-
-error.horn = {
-	toJSON() {
-		return 'x';
-	}
-};
-
-serializeError(error);
-// => {horn: 'x', name, message, stack}
-```
--->
-
-<!-- ### deserializeError(value, options?) -->
-### deserializeError(value)
+### deserializeError&lt;T extends Error&gt;(value: SerializedError): T
 
 Deserialize a plain object or any value into an `Error` object.
 
@@ -134,82 +87,4 @@ Deserialize a plain object or any value into an `Error` object.
 - Custom properties are **NOT** preserved
 - Non-enumerable properties are kept non-enumerable (name, message, stack, cause)
 - Circular references are **NOT** handled
-
-<!--
-- `Error` objects are passed through.
-- Objects that have at least a `message` property are interpreted as errors.
-- All other values are wrapped in a `NonError` error.
-- Custom properties are **NOT** preserved.
-- Non-enumerable properties are kept non-enumerable (name, message, stack, cause).
-- Enumerable properties are kept enumerable (all **common** properties besides the non-enumerable ones).
-- Circular references are **NOT** handled.
-- [Native error constructors](./src/constructors.js) are preserved (TypeError, DOMException, etc) and [more can be added.](#error-constructors)
--->
-
-### value
-
-Type: `{message: string} | unknown`
-
-<!--
-### options
-
-Type: `object`
-
-#### maxDepth
-
-Type: `number`\
-Default: `Number.POSITIVE_INFINITY`
-
-The maximum depth of properties to preserve when serializing/deserializing.
-
-```js
-import {serializeError} from 'serialize-error';
-
-const error = new Error('🦄');
-error.one = {two: {three: {}}};
-
-console.log(serializeError(error, {maxDepth: 1}));
-//=> {name: 'Error', message: '🦄', one: {}}
-
-console.log(serializeError(error, {maxDepth: 2}));
-//=> {name: 'Error', message: '🦄', one: { two: {}}}
-```
-
-#### useToJSON
-
-Type: `boolean`\
-Default: `true`
-
-Indicate whether to use a `.toJSON()` method if encountered in the object. This is useful when a custom error implements [its own serialization logic via `.toJSON()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#tojson_behavior) but you prefer to not use it.
-
-### isErrorLike(value)
-
-Predicate to determine whether a value looks like an error, even if it's not an instance of `Error`. It must have at least the `name`, `message`, and `stack` properties.
-
-```js
-import {isErrorLike} from 'serialize-error';
-
-const error = new Error('🦄');
-error.one = {two: {three: {}}};
-
-isErrorLike({
-	name: 'DOMException',
-	message: 'It happened',
-	stack: 'at foo (index.js:2:9)',
-});
-//=> true
-
-isErrorLike(new Error('🦄'));
-//=> true
-
-isErrorLike(serializeError(new Error('🦄'));
-//=> true
-
-isErrorLike({
-	name: 'Bluberricious pancakes',
-	stack: 12,
-	ingredients: 'Blueberry',
-});
-//=> false
-```
--->
+- The constructor method of the class is **NOT** called

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serialize-error-cjs",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serialize-error-cjs",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "license": "ISC",
       "devDependencies": {
         "@types/node": "^22.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serialize-error-cjs",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/src/constructors.ts
+++ b/src/constructors.ts
@@ -6,6 +6,7 @@ const list: [string, ErrorConstructor][] = [
   SyntaxError,
   TypeError,
   URIError,
+  globalThis.AggregateError,
   globalThis.DOMException,
   globalThis.AssertionError,
   globalThis.SystemError,

--- a/test/0004-aggregate-errors.ts
+++ b/test/0004-aggregate-errors.ts
@@ -1,16 +1,6 @@
 import test from 'tape';
 import {deserializeError, serializeError} from '../src';
 
-// Minimally polyfill AggregateError
-if (!globalThis.AggregateError) {
-  class AggregateError extends Error {
-    constructor(private errors: Error[], message?: string) {
-      super(message);
-    };
-  }
-  globalThis.AggregateError = AggregateError;
-}
-
 function randomString(length: number): string {
   let output = '';
   while(output.length < length) output += Math.random().toString(36).substring(2);

--- a/test/0004-aggregate-errors.ts
+++ b/test/0004-aggregate-errors.ts
@@ -1,0 +1,50 @@
+import test from 'tape';
+import {deserializeError, serializeError} from '../src';
+
+// Minimally polyfill AggregateError
+if (!globalThis.AggregateError) {
+  class AggregateError extends Error {
+    constructor(private errors: Error[], message?: string) {
+      super(message);
+    };
+  }
+  globalThis.AggregateError = AggregateError;
+}
+
+function randomString(length: number): string {
+  let output = '';
+  while(output.length < length) output += Math.random().toString(36).substring(2);
+  return output.substring(0, length);
+}
+
+test('Aggregate errors can be converted back-and-forth', t => {
+  const AggregateError = globalThis.AggregateError;
+
+  const err = new AggregateError([
+    new Error(randomString(16)),
+    new EvalError(randomString(16)),
+    new RangeError(randomString(16)),
+    new ReferenceError(randomString(16)),
+    new SyntaxError(randomString(16)),
+    new TypeError(randomString(16)),
+    new URIError(randomString(16)),
+  ]);
+
+  t.ok(err instanceof AggregateError, 'Pre-serialization is an instance of AggregateError');
+
+  const serialized = serializeError(err);
+  t.ok(serialized, 'Serialized error is truthy');
+  t.equal(typeof serialized, 'object', 'Serialized error is an object');
+  t.equal(serialized.name, AggregateError.name, 'Serialized name matches constructor name');
+
+  const deserialized = deserializeError<typeof AggregateError>(serialized);
+  t.ok(deserialized instanceof AggregateError, `Deserialized is an instance of ${AggregateError.name}`);
+
+  t.equal(deserialized.message, err.message, 'Deserialized message matches original');
+  for(let i=0; i < err.errors.length; i++) {
+    t.equal(Object.getPrototypeOf(err.errors[i]), Object.getPrototypeOf(deserialized.errors[i]), `Prototype match for entry ${i} in AggregateError`);
+    t.equal(err.errors[i].message, deserialized.errors[i].message, `Message match for entry ${i} in AggregateError`);
+  }
+
+  t.end();
+});

--- a/test/main.ts
+++ b/test/main.ts
@@ -2,4 +2,5 @@ import './0000-plain';
 import './0001-constructors';
 import './0002-singular-errors';
 import './0003-unknown-error-deserialize';
+import './0004-aggregate-errors';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "es2020",
     "module": "commonjs",
     "lib": ["ES2020", "DOM", "esnext.asynciterable"],
     "sourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2015",
     "module": "commonjs",
     "lib": ["ES2020", "DOM", "esnext.asynciterable"],
     "sourceMap": true,


### PR DESCRIPTION
### ⚠️ Possibly breaking changes ⚠️ 

Errors are deserialized using `Object.create` instead of calling the constructor of said errors. Any functionality in custom error classes relying on the constructor being called will no longer work.

### Changes

- Added support for AggregateError
- Initialize errors using Object.create instead of calling the constructor

### Fixes

- #5 